### PR TITLE
fix: wrong claim button

### DIFF
--- a/src/features/merkle-drop/api/web3.ts
+++ b/src/features/merkle-drop/api/web3.ts
@@ -142,11 +142,16 @@ export async function getTokensAvailableForWithdrawal(
     return 0n;
   }
 
-  const amounts = await userPoolContract.methods
-    .calculateVestedAmount(vestingId)
-    .call();
-
-  return BigInt(amounts["vestedAmount"]) - BigInt(amounts["claimedAmount"]);
+  try {
+    const amounts = await userPoolContract.methods
+      .calculateVestedAmount(vestingId)
+      .call();
+    return BigInt(amounts["vestedAmount"]) - BigInt(amounts["claimedAmount"]);
+  } catch (e) {
+    // the contract call can revert if the vesting is not active yet
+    // best to return 0 in such cases
+    return 0n;
+  }
 }
 
 export async function claimTokens(


### PR DESCRIPTION
If a vesting is not active yet, the call to calculateVestedAmounts reverts/throws in the javascript code. Since we don’t catch this subsequent calls to check the token paused state are not done and the UI ends up in a wrong state.

With this change we catch the error and the UI displays the correct info that the vesting cannot be transferred yet.